### PR TITLE
Fix button selector for squash button

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,5 +1,5 @@
 var squashMergeMessage = function() {
-  var squashButton = document.querySelector('.merge-message .btn-group-squash [type=submit]');
+  var squashButton = document.querySelector('.merge-message .btn-group-squash [type=button]');
   if (!squashButton) return;
 
   squashButton.addEventListener('click', function() {


### PR DESCRIPTION
The squash and merge button is of type button before previewing. But changes to submit only when it changes to confirm squash merge.

As a result the description is not getting populated in the textarea.