### PR TITLE
Fix squash button selector

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,5 +1,6 @@
 var squashMergeMessage = function() {
-  var squashButton = document.querySelector('.merge-message .btn-group-squash [type=button]');
+  var squashButton = document.querySelector('.merge-message .btn-group-squash');
+  
   if (!squashButton) return;
 
   squashButton.addEventListener('click', function() {


### PR DESCRIPTION
Github has changed the selector for squash and merge button.

This fixes by selecting the proper class.