### PR TITLE
Add Support for Merge Commits

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,29 +1,29 @@
-var copyPrDescription = function() {
-  var prTitleEl = document.getElementById("issue_title");
+const copyPrDescription = function() {
+  const prTitleEl = document.getElementById("issue_title");
   if (!prTitleEl) return;
 
-  var prNumberEl = document.querySelector(".gh-header-title .gh-header-number");
+  const prNumberEl = document.querySelector(".gh-header-title .gh-header-number");
   if (!prNumberEl) return;
 
-  var prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
+  const prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
   if (!prBodyEl) return;
 
-  var titleField = document.getElementById('merge_title_field');
+  const titleField = document.getElementById('merge_title_field');
   if (!titleField) return;
 
-  var messageField = document.getElementById('merge_message_field');
+  const messageField = document.getElementById('merge_message_field');
   if (!messageField) return;
 
-  var commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
-  var commitBody = prBodyEl.textContent;
+  const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
+  const commitBody = prBodyEl.textContent;
 
   titleField.value = commitTitle;
   messageField.value = commitBody;
 }
 
-var addMergeListeners = function() {
-  var squashButton = document.querySelector('.merge-message .btn-group-squash');
-  var mergeButton = document.querySelector('.merge-message .btn-group-merge');
+const addMergeListeners = function() {
+  const squashButton = document.querySelector('.merge-message .btn-group-squash');
+  const mergeButton = document.querySelector('.merge-message .btn-group-merge');
 
   if (squashButton) {
     squashButton.addEventListener('click', copyPrDescription);

--- a/content.js
+++ b/content.js
@@ -1,18 +1,38 @@
-var squashMergeMessage = function() {
-  var squashButton = document.querySelector('.merge-message .btn-group-squash');
-  
-  if (!squashButton) return;
+var copyPrDescription = function() {
+  var prTitleEl = document.getElementById("issue_title");
+  if (!prTitleEl) return;
 
-  squashButton.addEventListener('click', function() {
-    var description = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
-    if (!description) return;
+  var prNumberEl = document.querySelector(".gh-header-title .gh-header-number");
+  if (!prNumberEl) return;
 
-    var messageField = document.getElementById('merge_message_field');
-    if (!messageField) return;
+  var prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
+  if (!prBodyEl) return;
 
-    messageField.value = description.textContent;
-  });
+  var titleField = document.getElementById('merge_title_field');
+  if (!titleField) return;
+
+  var messageField = document.getElementById('merge_message_field');
+  if (!messageField) return;
+
+  var commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
+  var commitBody = prBodyEl.textContent;
+
+  titleField.value = commitTitle;
+  messageField.value = commitBody;
 }
 
-document.addEventListener('pjax:end', squashMergeMessage);
-squashMergeMessage();
+var addMergeListeners = function() {
+  var squashButton = document.querySelector('.merge-message .btn-group-squash');
+  var mergeButton = document.querySelector('.merge-message .btn-group-merge');
+
+  if (squashButton) {
+    squashButton.addEventListener('click', copyPrDescription);
+  }
+  if (mergeButton) {
+    mergeButton.addEventListener('click', copyPrDescription);
+  }
+
+}
+
+document.addEventListener('pjax:end', addMergeListeners);
+addMergeListeners();

--- a/content.js
+++ b/content.js
@@ -1,4 +1,4 @@
-const copyPrDescription = function() {
+fucntion copyPrDescription() {
   const prTitleEl = document.getElementById("issue_title");
   if (!prTitleEl) return;
 
@@ -21,7 +21,7 @@ const copyPrDescription = function() {
   messageField.value = commitBody;
 }
 
-const addMergeListeners = function() {
+function addMergeListeners() {
   const squashButton = document.querySelector('.merge-message .btn-group-squash');
   const mergeButton = document.querySelector('.merge-message .btn-group-merge');
 

--- a/content.js
+++ b/content.js
@@ -1,4 +1,4 @@
-fucntion copyPrDescription() {
+function copyPrDescription() {
   const prTitleEl = document.getElementById("issue_title");
   if (!prTitleEl) return;
 


### PR DESCRIPTION
Adds support for copying PR title and body to merge commits as well.

Also includes some incidental cleanup to use ES6 constructs (mostly `const`), which I'm happy to drop if not desired.

Tested locally on Chrome 83.0.4103.116

Fixes #8