### PR TITLE
Change event listeners

### DIFF
--- a/content.js
+++ b/content.js
@@ -21,18 +21,24 @@ function copyPrDescription() {
   messageField.value = commitBody;
 }
 
-function addMergeListeners() {
-  const squashButton = document.querySelector('.merge-message .btn-group-squash');
-  const mergeButton = document.querySelector('.merge-message .btn-group-merge');
+function addMergeListener() {
+  if (!window.location.pathname.match("/pull/[0-9]+$")) return;
 
-  if (squashButton) {
-    squashButton.addEventListener('click', copyPrDescription);
-  }
-  if (mergeButton) {
-    mergeButton.addEventListener('click', copyPrDescription);
-  }
+  const prMergePanel = document.querySelector('.js-merge-pr:not(.is-rebasing)');
+  if (!prMergePanel) return;
 
+  prMergePanel.addEventListener('details:toggled', copyPrDescription);
 }
 
-document.addEventListener('pjax:end', addMergeListeners);
-addMergeListeners();
+// Run on extension load.
+addMergeListener();
+
+// Run on session resume.
+document.addEventListener('session:resume', addMergeListener);
+
+// Run when new comments are added, removed, edited, etc.
+const comments = document.querySelector('.js-discussion');
+if (comments) {
+  const observer = new MutationObserver(addMergeListener);
+  observer.observe(comments, {childList: true});
+}

--- a/content.js
+++ b/content.js
@@ -22,23 +22,30 @@ function copyPrDescription(event) {
 }
 
 function addMergeListener(event) {
-  if (!window.location.pathname.match("/pull/[0-9]+$")) return;
-
   const prMergePanel = document.querySelector('.js-merge-pr:not(.is-rebasing)');
   if (!prMergePanel) return;
 
   prMergePanel.addEventListener('details:toggled', copyPrDescription);
 }
 
-// Run on extension load.
-addMergeListener();
+function main() {
+  // Only run on PR pages
+  if (!window.location.pathname.match("/pull/[0-9]+$")) return;
 
-// Run on AJAX.
-document.addEventListener('pjax:end', addMergeListener);
+  // Add merge listeners on load
+  addMergeListener();
 
-// Run when new comments are added, removed, edited, etc.
-const comments = document.querySelector('.js-discussion');
-if (comments) {
-  const observer = new MutationObserver(addMergeListener);
-  observer.observe(comments, {childList: true});
+  // And on AJAX events
+  // (Happens when you switch from PR diff or commits back to merge)
+  document.addEventListener('pjax:end', addMergeListener);
+
+  // And when new comments are added, removed, edited, etc.
+  // (I don't know why, but it works ¯\_(ツ)_/¯)
+  const comments = document.querySelector('.js-discussion');
+  if (comments) {
+    const observer = new MutationObserver(addMergeListener);
+    observer.observe(comments, {childList: true});
+  }
 }
+
+main();

--- a/content.js
+++ b/content.js
@@ -33,8 +33,8 @@ function addMergeListener(event) {
 // Run on extension load.
 addMergeListener();
 
-// Run on session resume.
-document.addEventListener('session:resume', addMergeListener);
+// Run on AJAX.
+document.addEventListener('pjax:end', addMergeListener);
 
 // Run when new comments are added, removed, edited, etc.
 const comments = document.querySelector('.js-discussion');

--- a/content.js
+++ b/content.js
@@ -1,4 +1,4 @@
-function copyPrDescription() {
+function copyPrDescription(event) {
   const prTitleEl = document.getElementById("issue_title");
   if (!prTitleEl) return;
 
@@ -21,7 +21,7 @@ function copyPrDescription() {
   messageField.value = commitBody;
 }
 
-function addMergeListener() {
+function addMergeListener(event) {
   if (!window.location.pathname.match("/pull/[0-9]+$")) return;
 
   const prMergePanel = document.querySelector('.js-merge-pr:not(.is-rebasing)');

--- a/content.js
+++ b/content.js
@@ -40,7 +40,7 @@ function main() {
   document.addEventListener('pjax:end', addMergeListener);
 
   // And when new comments are added, removed, edited, etc.
-  // (I don't know why, but it works ¯\_(ツ)_/¯)
+  // (Something about how GitHub refreshes the comments discards all events ¯\_(ツ)_/¯)
   const comments = document.querySelector('.js-discussion');
   if (comments) {
     const observer = new MutationObserver(addMergeListener);


### PR DESCRIPTION
Do not add listeners if page is not a PR page.
Use a single event for both Squash and Merge.
Re-add listeners on new comments.

Fixes #11 

Inspiration
- https://github.com/sindresorhus/refined-github/blob/master/source/github-events/on-new-comments.ts
- https://github.com/sindresorhus/refined-github/blob/master/source/github-events/on-pr-merge-panel-open.ts