### PR TITLE
Message Body: Keep Co-Authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ and body, respectively. The final commit on the base branch will look like:
 PR Title (#1234)
 
 PR Body
+
+Co-authored-by: ... (if multiple authors)
 ```
 
 ## Refined GitHub Compatibility

--- a/content.js
+++ b/content.js
@@ -1,9 +1,3 @@
-function uniqueLines(arr) {
-  return arr.filter(function (value, index, self) {
-    return self.indexOf(value) === index;
-  });
-}
-
 function copyPrDescription(event) {
   const prTitleEl = document.getElementById("issue_title");
   if (!prTitleEl) return;
@@ -20,10 +14,13 @@ function copyPrDescription(event) {
   const messageField = document.getElementById('merge_message_field');
   if (!messageField) return;
 
-  const coauthors = uniqueLines(messageField.value.match(/(Co-authored-by: .*)/g));
+  const coauthors = new Set(messageField.value.matchAll(/Co-authored-by: .*/g));
 
   const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
-  const commitBody = prBodyEl.textContent + '\n\n' + coauthors.join('\n');
+  let commitBody = prBodyEl.textContent
+  if (coauthors.size > 0) {
+    commitBody += '\n\n' + [...coauthors].join('\n');
+  }
 
   titleField.value = commitTitle;
   messageField.value = commitBody;

--- a/content.js
+++ b/content.js
@@ -1,3 +1,9 @@
+function uniqueLines(arr) {
+  return arr.filter(function (value, index, self) {
+    return self.indexOf(value) === index;
+  });
+}
+
 function copyPrDescription(event) {
   const prTitleEl = document.getElementById("issue_title");
   if (!prTitleEl) return;
@@ -14,8 +20,10 @@ function copyPrDescription(event) {
   const messageField = document.getElementById('merge_message_field');
   if (!messageField) return;
 
+  const coauthors = uniqueLines(messageField.value.match(/(Co-authored-by: .*)/g));
+
   const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
-  const commitBody = prBodyEl.textContent;
+  const commitBody = prBodyEl.textContent + '\n\n' + coauthors.join('\n');
 
   titleField.value = commitTitle;
   messageField.value = commitBody;

--- a/content.js
+++ b/content.js
@@ -17,7 +17,7 @@ function copyPrDescription(event) {
   const coauthors = new Set(messageField.value.matchAll(/Co-authored-by: .*/g));
 
   const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
-  let commitBody = prBodyEl.textContent
+  let commitBody = prBodyEl.textContent;
   if (coauthors.size > 0) {
     commitBody += '\n\n' + [...coauthors].join('\n');
   }


### PR DESCRIPTION
This keeps the original co-authors as determined by GitHub in the squash commit message.

Improvements over GitHub default:
- only name each co-author once
- placed at the end of the squash commit message

Tested locally on Firefox 78.0.2 (on Ubuntu 18.04) following this guide:
  https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension

Close #13 