### PR TITLE
Remove HTML comments from body

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ domain* to enable the extension on your custom GitHub Enterprise domain.
 
 When merging a PR with either the "Squash and merge" or "Create a merge commit"
 buttons, the commit title and message will be copied from the Pull Request title
-and body, respectively. The final commit on the base branch will look like:
+and body, respectively, and any leading HTML comments will be removed.
+
+The final commit on the base branch will look like:
 
 ```
 PR Title (#1234)

--- a/content.js
+++ b/content.js
@@ -14,13 +14,17 @@ function copyPrDescription(event) {
   const messageField = document.getElementById('merge_message_field');
   if (!messageField) return;
 
+  let prBody = prBodyEl.textContent;
+  // Preserve and de-duplicate co-authors
   const coauthors = new Set(messageField.value.match(/Co-authored-by: .*/g));
+  if (coauthors.size > 0) {
+    prBody += '\n\n' + [...coauthors].join('\n');
+  }
+  // Remove leading HTML comments
+  prBody = prBody.replace(/^<!--.*?-->\n?/gs, '')
 
   const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
-  let commitBody = prBodyEl.textContent;
-  if (coauthors.size > 0) {
-    commitBody += '\n\n' + [...coauthors].join('\n');
-  }
+  const commitBody = prBody
 
   titleField.value = commitTitle;
   messageField.value = commitBody;

--- a/content.js
+++ b/content.js
@@ -21,10 +21,10 @@ function copyPrDescription(event) {
     prBody += '\n\n' + [...coauthors].join('\n');
   }
   // Remove leading HTML comments
-  prBody = prBody.replace(/^<!--.*?-->\n*/gs, '')
+  prBody = prBody.replace(/^<!--.*?-->\n*/gs, '');
 
   const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
-  const commitBody = prBody
+  const commitBody = prBody;
 
   titleField.value = commitTitle;
   messageField.value = commitBody;

--- a/content.js
+++ b/content.js
@@ -21,7 +21,7 @@ function copyPrDescription(event) {
     prBody += '\n\n' + [...coauthors].join('\n');
   }
   // Remove leading HTML comments
-  prBody = prBody.replace(/^<!--.*?-->\n?/gs, '')
+  prBody = prBody.replace(/^<!--.*?-->\n*/gs, '')
 
   const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
   const commitBody = prBody

--- a/content.js
+++ b/content.js
@@ -14,17 +14,16 @@ function copyPrDescription(event) {
   const messageField = document.getElementById('merge_message_field');
   if (!messageField) return;
 
-  let prBody = prBodyEl.textContent;
+  const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
+
+  // Remove leading HTML comments
+  let commitBody = prBodyEl.textContent.replace(/^<!--.*?-->\n*/gs, '');
+
   // Preserve and de-duplicate co-authors
   const coauthors = new Set(messageField.value.match(/Co-authored-by: .*/g));
   if (coauthors.size > 0) {
-    prBody += '\n\n' + [...coauthors].join('\n');
+    commitBody += '\n\n' + [...coauthors].join('\n');
   }
-  // Remove leading HTML comments
-  prBody = prBody.replace(/^<!--.*?-->\n*/gs, '');
-
-  const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
-  const commitBody = prBody;
 
   titleField.value = commitTitle;
   messageField.value = commitBody;


### PR DESCRIPTION
<!-- Like this :) -->

Folks like to add comments to the beginning of their PR templates that are invisible while looking at the PR page but would show up in the final squash message.

This change removes those comments from the final commit message.

Closes #17 