### PR TITLE
Get PR number from URL

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,20 +1,42 @@
+function warn(message) {
+  console.warn(`squashed-merge-message: ${message}`);
+}
+
 function copyPrDescription(event) {
-  const prTitleEl = document.getElementById("issue_title");
-  if (!prTitleEl) return;
+  const prTitleEl = document.getElementById('issue_title');
+  if (!prTitleEl) {
+    warn('failed to find PR title element');
+    return;
+  };
 
-  const prNumberEl = document.querySelector(".gh-header-title .gh-header-number");
-  if (!prNumberEl) return;
+  const prNumberMatch =
+      window.location.pathname.match('/pull/(?<pr_number>[0-9]+)$');
+  if (!prNumberMatch) {
+    warn('failed to find match for PR number in URL');
+    return;
+  };
 
-  const prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
-  if (!prBodyEl) return;
+  const prBodyEl = document.querySelector(
+      '.comment-form-textarea[name="pull_request[body]"]');
+  if (!prBodyEl) {
+    warn('failed to find PR body element');
+    return;
+  };
 
   const titleField = document.getElementById('merge_title_field');
-  if (!titleField) return;
+  if (!titleField) {
+    warn('failed to find merge commit title field');
+    return;
+  };
 
   const messageField = document.getElementById('merge_message_field');
-  if (!messageField) return;
+  if (!messageField) {
+    warn('failed to find merge commit body field');
+    return;
+  };
 
-  const commitTitle = `${prTitleEl.value} (${prNumberEl.textContent})`;
+  const commitTitle =
+      `${prTitleEl.value} (${prNumberMatch.groups['pr_number']})`;
 
   // Remove leading HTML comments
   let commitBody = prBodyEl.textContent.replace(/^<!--.*?-->\n*/gs, '');
@@ -38,7 +60,7 @@ function addMergeListener(event) {
 
 function main() {
   // Only run on PR pages
-  if (!window.location.pathname.match("/pull/[0-9]+$")) return;
+  if (!window.location.pathname.match('/pull/[0-9]+$')) return;
 
   // Add merge listeners on load
   addMergeListener();
@@ -48,7 +70,8 @@ function main() {
   document.addEventListener('pjax:end', addMergeListener);
 
   // And when new comments are added, removed, edited, etc.
-  // (Something about how GitHub refreshes the comments discards all events ¯\_(ツ)_/¯)
+  // (Something about how GitHub refreshes the comments discards all events
+  // ¯\_(ツ)_/¯)
   const comments = document.querySelector('.js-discussion');
   if (comments) {
     const observer = new MutationObserver(addMergeListener);

--- a/content.js
+++ b/content.js
@@ -9,15 +9,13 @@ function copyPrDescription(event) {
     return;
   };
 
-  const prNumberMatch =
-      window.location.pathname.match('/pull/(?<pr_number>[0-9]+)$');
+  const prNumberMatch = window.location.pathname.match('/pull/(?<pr_number>[0-9]+)$');
   if (!prNumberMatch) {
     warn('failed to find match for PR number in URL');
     return;
   };
 
-  const prBodyEl = document.querySelector(
-      '.comment-form-textarea[name="pull_request[body]"]');
+  const prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
   if (!prBodyEl) {
     warn('failed to find PR body element');
     return;
@@ -35,8 +33,7 @@ function copyPrDescription(event) {
     return;
   };
 
-  const commitTitle =
-      `${prTitleEl.value} (${prNumberMatch.groups['pr_number']})`;
+  const commitTitle = `${prTitleEl.value} (${prNumberMatch.groups['pr_number']})`;
 
   // Remove leading HTML comments
   let commitBody = prBodyEl.textContent.replace(/^<!--.*?-->\n*/gs, '');
@@ -70,8 +67,7 @@ function main() {
   document.addEventListener('pjax:end', addMergeListener);
 
   // And when new comments are added, removed, edited, etc.
-  // (Something about how GitHub refreshes the comments discards all events
-  // ¯\_(ツ)_/¯)
+  // (Something about how GitHub refreshes the comments discards all events ¯\_(ツ)_/¯)
   const comments = document.querySelector('.js-discussion');
   if (comments) {
     const observer = new MutationObserver(addMergeListener);


### PR DESCRIPTION
The selectors for the PR number element have changed which breaks the
current method. The new selectors do not look like good ones to use and
fetching from the URL should be more stable.

Also adds logging to failures, which was helpful in debugging this
issue.
