### PR TITLE
Fix selector to find PR body element

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,10 +15,13 @@ function copyPrDescription(event) {
     return;
   };
 
-  const prBodyEl = document.querySelector('.comment-form-textarea[name="issue[body]"]');
+  let prBodyEl = document.querySelector('.comment-form-textarea[name="issue[body]"]');
   if (!prBodyEl) {
-    warn('failed to find PR body element');
-    return;
+    prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
+    if (!prBodyEl) {
+      warn('failed to find PR body element');
+      return;
+    };
   };
 
   // When using auto-merge, GitHub has two text fields with the same ID.

--- a/content.js
+++ b/content.js
@@ -15,7 +15,7 @@ function copyPrDescription(event) {
     return;
   };
 
-  const prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
+  const prBodyEl = document.querySelector('.comment-form-textarea[name="issue[body]"]');
   if (!prBodyEl) {
     warn('failed to find PR body element');
     return;


### PR DESCRIPTION
Yesterday, I started getting the warning log `failed to find PR body element` in my environment.
It seems that the `pull_request[body]` in the selector for PR body element has been changed to `issue[body]`.
Could you please check it?

FYI: I've confirmed that the change works in my environment.

![SS](https://user-images.githubusercontent.com/1025342/133725653-a6a1e719-e7fe-4449-8510-056de7880977.png)
