### PR TITLE
fix: Fix failure to copy description

### DIFF
--- a/content.js
+++ b/content.js
@@ -96,6 +96,8 @@ async function makePrDescriptionAppear() {
   editButton.click();
   const cancelButton = await waitForElement('button.js-comment-cancel-button.btn-danger.btn');
   cancelButton.click();
+  const commitText = document.getElementById('merge_message_field');
+  commitText.focus();
 }
 
 function waitForElement(selector) {

--- a/content.js
+++ b/content.js
@@ -19,7 +19,7 @@ async function copyPrDescription() {
 
   let prMetadata = await getPrMetadataFromDocument();
   if (!prMetadata) {
-    prMetadata = await getPrMetadataFromApi();
+    prMetadata = await getPrMetadataFromApi(repo, prNumber);
   }
   if (!prMetadata) {
     warn('failed to pull PR metadata from document or API');

--- a/content.js
+++ b/content.js
@@ -9,17 +9,18 @@ function debug(message) {
 async function copyPrDescription() {
   debug('copy PR description');
 
+  const match = window.location.pathname.match('^/(?<repo>[^/]+/[^/]+)/pull/(?<pr_number>[0-9]+)$');
+  if (!match) {
+    warn('failed to find match for repo and PR number in URL');
+    return;
+  };
+  const repo = match.groups['repo'];
+  const prNumber = match.groups['pr_number'];
+
   let prMetadata = null;
 
   // For public repos, prefer the API.
   if (window.location.host == 'github.com') {
-    const match = window.location.pathname.match('^/(?<repo>[^/]+/[^/]+)/pull/(?<pr_number>[0-9]+)$');
-    if (!match) {
-      warn('failed to find match for repo and PR number in URL');
-      return;
-    };
-    const repo = match.groups['repo'];
-    const prNumber = match.groups['pr_number'];
     prMetadata = await getPrMetadataFromApi(repo, prNumber);
   }
 

--- a/content.js
+++ b/content.js
@@ -17,8 +17,14 @@ async function copyPrDescription() {
   const repo = match.groups['repo'];
   const prNumber = match.groups['pr_number'];
 
-  const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${prNumber}`);
-  const prMetadata = await response.json();
+  let prMetadata = await getPrMetadataFromDocument();
+  if (!prMetadata) {
+    prMetadata = await getPrMetadataFromApi();
+  }
+  if (!prMetadata) {
+    warn('failed to pull PR metadata from document or API');
+    return;
+  }
 
   // When using auto-merge, GitHub has two text fields with the same ID.
   const titleFields = document.querySelectorAll('[id=merge_title_field]');
@@ -47,6 +53,49 @@ async function copyPrDescription() {
 
   titleFields.forEach(f => f.value = commitTitle);
   messageFields.forEach(f => f.value = commitBody);
+}
+
+async function getPrMetadataFromDocument() {
+  await makePrDescriptionAppear();
+
+  const prTitleEl = document.getElementById('issue_title');
+  if (!prTitleEl) {
+    warn('failed to find PR title element');
+    return null;
+  }
+
+  let prBodyEl = document.querySelector('.comment-form-textarea[name="issue[body]"]');
+  if (!prBodyEl) {
+    prBodyEl = document.querySelector('.comment-form-textarea[name="pull_request[body]"]');
+    if (!prBodyEl) {
+      warn('failed to find PR body element');
+      return null;
+    }
+  }
+
+  return {
+    title: prTitleEl.value,
+    body: prBodyEl.textContent,
+  };
+}
+
+async function getPrMetadataFromApi(repo, prNumber) {
+  const response = await fetch(`https://api.github.com/repos/${repo}/pulls/${prNumber}`);
+  const prMetadata = await response.json();
+  return {
+    // These could be null in some cases, so replace nulls with empty strings.
+    title: prMetadata.title || '',
+    body: prMetadata.body || '',
+  };
+}
+
+async function makePrDescriptionAppear() {
+  const detailsButton = document.querySelector('.timeline-comment-actions details:last-child summary[role="button"]');
+  detailsButton.click();
+  const editButton = await waitForElement('details-menu > button.dropdown-item.btn-link.js-comment-edit-button');
+  editButton.click();
+  const cancelButton = await waitForElement('button.js-comment-cancel-button.btn-danger.btn');
+  cancelButton.click();
 }
 
 function waitForElement(selector) {

--- a/content.js
+++ b/content.js
@@ -43,7 +43,7 @@ async function copyPrDescription() {
   const commitTitle = `${prMetadata.title} (#${prNumber})`;
 
   // Remove leading HTML comments
-  let commitBody = prMetadata.body.replace(/^<!--.*?-->\n*/gs, '');
+  let commitBody = prMetadata.body.replace(/^<!--.*?-->\n*/gs, '').trim();
 
   // Preserve and de-duplicate co-authors
   const coauthors = new Set(messageFields[0].value.match(/Co-authored-by: .*/g));

--- a/content.js
+++ b/content.js
@@ -20,7 +20,7 @@ async function copyPrDescription() {
   let prMetadata = null;
 
   // For public repos, prefer the API.
-  if (window.location.host == 'github.com') {
+  if (window.location.host === 'github.com') {
     prMetadata = await getPrMetadataFromApi(repo, prNumber);
   }
 


### PR DESCRIPTION
Instead of copying the PR title and body from the HTML elements, which
may not exist yet, use the GitHub API to query the necessary metadata.

Closes #11